### PR TITLE
Null pointer dereference line 111 at `conf.c`

### DIFF
--- a/ksysguardd/conf.c
+++ b/ksysguardd/conf.c
@@ -107,12 +107,18 @@ void parseConfigFile( const char *filename )
           continue;
         }
         confLog->name = strdup( token );
-        tmp = strchr( confLog->name, ':' );
-        *tmp = '\0';
-        confLog->path = tmp;
-        confLog->path++;
-
-        push_ctnr( LogFileList, confLog );
+        if((tmp = strchr( confLog->name, ':' )) != NULL)
+        {
+          *tmp = '\0';
+          confLog->path = tmp;
+          confLog->path++;
+          push_ctnr( LogFileList, confLog );
+        }
+        else
+        {
+          print_error("Invalid config file");
+          exit(EXIT_FAILURE);
+        }
       }
     }
 


### PR DESCRIPTION
I think there is a null ptr defererence at line 111 where you attempt to write at `*tmp`.
I just added a check and exit if the ptr is `null`