### PR TITLE
Increase CPUINFOBUFSIZE to 128kb

### DIFF
--- a/ksysguardd/Linux/cpuinfo.c
+++ b/ksysguardd/Linux/cpuinfo.c
@@ -40,7 +40,7 @@ static int numCores = 0; /* Total # of cores */
 static int HighNumCores = 0; /* Highest # of cores ever seen */
 static float* Clocks = 0; /* Array with one entry per core */
 
-#define CPUINFOBUFSIZE (32 * 1024)
+#define CPUINFOBUFSIZE (128 * 1024)
 static char CpuInfoBuf[ CPUINFOBUFSIZE ];
 static int Dirty = 0;
 static struct SensorModul *CpuInfoSM;


### PR DESCRIPTION
Output of command "/proc/cpuinfo" is written to a buffer CpuInfoBuf with a size of CPUINFOBUFSIZE.
Size is checked in "int updateCpuInfo( void )"
If there are too many processors in the system - old value of 32kb is not enough.